### PR TITLE
fix: resolve OOM issues and improve deployment stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,12 @@ ENV APP_ENV=production \
 # Expose web port for fly
 EXPOSE 8080
 
-# (optional) PHP ini tweaks
-RUN mkdir -p /app/.infra \
- && printf "opcache.enable=1\nopcache.jit_buffer_size=0\n" > /app/.infra/php.ini
+# PHP ini tweaks
+RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/opcache.ini \
+ && echo "opcache.jit_buffer_size=0" >> /usr/local/etc/php/conf.d/opcache.ini \
+ && echo "memory_limit=200M" >> /usr/local/etc/php/conf.d/custom.ini \
+ && echo "post_max_size=20M" >> /usr/local/etc/php/conf.d/custom.ini \
+ && echo "upload_max_filesize=20M" >> /usr/local/etc/php/conf.d/custom.ini
 
 # Start supervisor which will manage both FrankenPHP and queue worker
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -6,7 +6,7 @@ logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [program:frankenphp]
-command=frankenphp php-server -r public/ -l :8080
+command=frankenphp php-server -r public/ -l 0.0.0.0:8080
 directory=/app
 autostart=true
 autorestart=true

--- a/fly.toml
+++ b/fly.toml
@@ -39,9 +39,9 @@ kill_timeout = "5s"
 
   [[http_service.checks]]
     name = "web"
-    interval = "10s"
-    timeout = "2s"
-    grace_period = "10s"
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "30s"
     method = "GET"
     path = "/up"
     protocol = "http"


### PR DESCRIPTION
- Add memory_limit=200M for PHP processes
- Configure FrankenPHP to listen on 0.0.0.0:8080 for Fly.io proxy
- Increase health check timeouts (15s interval, 5s timeout, 30s grace)
- Manually scaled Fly.io machine to 1GB RAM to support concurrent web + queue worker

Fixes Out of Memory errors during AI classification that were killing FrankenPHP and causing data loss.